### PR TITLE
Remove goo.gl reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/Vinelab/url-shortener/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/Vinelab/url-shortener/?branch=master)
 [![License](https://poser.pugx.org/vinelab/url-shortener/license)](https://packagist.org/packages/vinelab/url-shortener)
 
-**`vinelab/url-shortener`** is a PHP framework agnostic Package that makes it easy to shorten your URL's, with your favourite URL Shortening provider such as (Bit.ly, Goo.gl, Ow.ly).
+**`vinelab/url-shortener`** is a PHP framework agnostic Package that makes it easy to shorten your URL's, with your favourite URL Shortening provider such as (Bit.ly, Ow.ly).
 
 *The URL Shortening Providers are online services that takes long URLs and squeezes them into fewer characters to make the link easier to share, tweet, or send by email.*
 


### PR DESCRIPTION
goo.gl URL shortening was discontinued in March 2019 as seen [here](https://developers.google.com/url-shortener/) and [here](https://goo.gl/).
I've removed the README references to it.
It's up to you to remove it from the project's description however.

Cheers